### PR TITLE
Support flatpak'ed Telegram from FlatHub

### DIFF
--- a/messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml
+++ b/messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml
@@ -26,7 +26,7 @@
       <description>The color used to paint the Icon(GNOME 42 and later)</description>
     </key>
     <key name="compatible-chats" type="s">
-      <default>'amsn;caprine;chat.rocket.RocketChat;im.dino.Dino;emesene;empathy;fedora-empathy;gajim;hexchat;io.github.qtox.qTox;kadu;kde4-kmess;kde4-konversation;kde4-kopete;Nextcloud.Talk;openfetion;org.gnome.Fractal;org.gnome.Polari;pidgin;qtox;qutim;signal-desktop;skype;skypeforlinux;slack;telegramdesktop;utox;venom;viber;xchat;discord;Zoom'</default>
+      <default>'amsn;caprine;chat.rocket.RocketChat;im.dino.Dino;emesene;empathy;fedora-empathy;gajim;hexchat;io.github.qtox.qTox;kadu;kde4-kmess;kde4-konversation;kde4-kopete;Nextcloud.Talk;openfetion;org.gnome.Fractal;org.gnome.Polari;org.telegram.desktop;pidgin;qtox;qutim;signal-desktop;skype;skypeforlinux;slack;telegramdesktop;utox;venom;viber;xchat;discord;Zoom'</default>
       <summary>Compatible Chats</summary>
       <description>case sensitive name of the .desktop file names to start the app (without .desktop ending) delimited by semicolon</description>
     </key>


### PR DESCRIPTION
Add https://flathub.org/apps/org.telegram.desktop to the list of chat apps