### PR TITLE
Renames 'Developing' section to 'Contributing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd gnome-shell-extension-messagingmenu
 
 Now restart gnome-shell.
 
-## Developing
+## Contributing
 
 Pull requests are welcome.
 


### PR DESCRIPTION
Updates the README to clarify that the section is for contribution guidelines rather than general development.
