### PR TITLE
Updates compatible chat and email clients

### DIFF
--- a/messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml
+++ b/messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml
@@ -26,7 +26,7 @@
       <description>The color used to paint the Icon(GNOME 42 and later)</description>
     </key>
     <key name="compatible-chats" type="s">
-      <default>'amsn;caprine;chat.rocket.RocketChat;im.dino.Dino;emesene;empathy;fedora-empathy;gajim;hexchat;io.github.qtox.qTox;kadu;kde4-kmess;kde4-konversation;kde4-kopete;com.nextcloud.talk;openfetion;org.gnome.Fractal;org.gnome.Polari;org.telegram.desktop;pidgin;qtox;qutim;signal-desktop;skype;skypeforlinux;slack;telegramdesktop;utox;venom;viber;xchat;discord;Zoom'</default>
+      <default>'amsn;caprine;chat.rocket.RocketChat;im.dino.Dino;emesene;empathy;fedora-empathy;gajim;hexchat;io.github.qtox.qTox;kadu;kde4-kmess;kde4-konversation;kde4-kopete;com.nextcloud.talk;openfetion;org.gnome.Fractal;org.gnome.Polari;org.telegram.desktop;pidgin;qtox;qutim;signal-desktop;org.signal.Signal;skype;skypeforlinux;slack;telegramdesktop;utox;venom;viber;xchat;discord;Zoom'</default>
       <summary>Compatible Chats</summary>
       <description>Case sensitive name of the .desktop file names to start the app (without .desktop ending) delimited by semicolon</description>
     </key>
@@ -36,7 +36,7 @@
       <description>Case sensitive name of the .desktop file names to start the app (without .desktop ending) delimited by semicolon</description>
     </key>
     <key name="compatible-emails" type="s">
-      <default>'claws-mail;evolution;geary;gnome-gmail;icedove;kde4-KMail2;mozilla-thunderbird;org.gnome.Evolution;org.gnome.Geary;postler;thunderbird'</default>
+      <default>'claws-mail;evolution;geary;gnome-gmail;icedove;kde4-KMail2;mozilla-thunderbird;org.mozilla.Thunderbird;org.gnome.Evolution;org.gnome.Geary;postler;thunderbird'</default>
       <summary>Compatible Emails</summary>
       <description>Case sensitive name of the .desktop file names to start the app (without .desktop ending) delimited by semicolon</description>
     </key>


### PR DESCRIPTION
Updates the lists of compatible chat and email clients in the schema.

Adds 'org.signal.Signal' to the compatible chats list and
'org.mozilla.Thunderbird' to the compatible emails list,
ensuring better integration with these applications.
