### PR TITLE
Updates for GNOME Shell 49 and adds reset button

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{js,ts,css}]
+indent_size = 4

--- a/install.sh
+++ b/install.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
 
-# glib-compile-schemas messagingmenu\@lauinger-clan.de/schemas/
+extension="messagingmenu@lauinger-clan.de"
+extensionfile=$extension".shell-extension.zip"
 
-cd messagingmenu\@lauinger-clan.de
-gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=\ui --extra-source=\icons --extra-source=../LICENSE --force
-cd ..
+echo "Running $0 for $extension with arguments: $@"
 
 case "$1" in
   zip|pack)
+    cd $extension
+    gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=./lib --extra-source=./ui/ --extra-source=./icons/ --extra-source=../LICENSE --force
+    cd ..
     echo "Extension zip created ..."
     ;;
   install)
-    gnome-extensions install messagingmenu\@lauinger-clan.de.shell-extension.zip --force
-    gnome-extensions enable messagingmenu\@lauinger-clan.de
+    if [ ! -f $extensionfile ]; then
+      $0 zip
+    fi
+    gnome-extensions install $extensionfile --force
+    gnome-extensions enable $extension
+    echo "Extension zip installed ..."
     ;;
   upload)
-    gnome-extensions upload messagingmenu\@lauinger-clan.de.shell-extension.zip
+    if [ ! -f $extensionfile ]; then
+      $0 zip
+    fi
+    gnome-extensions upload --user ChrisLauinger77 --password-file /mnt/2TB/dev/ego_password $extensionfile
     ;;
   *)
-  echo "Usage: $0 {zip|pack|install|upload}"
+    echo "Usage: $0 {zip|pack|install|upload}"
     exit 1
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -3,13 +3,22 @@
 # glib-compile-schemas messagingmenu\@lauinger-clan.de/schemas/
 
 cd messagingmenu\@lauinger-clan.de
-gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=\ui --extra-source=\icons --extra-source=../LICENSE
+gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=\ui --extra-source=\icons --extra-source=../LICENSE --force
 cd ..
-mv messagingmenu@lauinger-clan.de.shell-extension.zip messagingmenu@lauinger-clan.de.zip
 
-if [ "$1" = "zip" ] || [ "$1" = "pack" ]; then
-   echo "Extension zip created ..."
-else
-   gnome-extensions install messagingmenu\@lauinger-clan.de.zip --force
-   gnome-extensions enable messagingmenu\@lauinger-clan.de
-fi
+case "$1" in
+  zip|pack)
+    echo "Extension zip created ..."
+    ;;
+  install)
+    gnome-extensions install messagingmenu\@lauinger-clan.de.shell-extension.zip --force
+    gnome-extensions enable messagingmenu\@lauinger-clan.de
+    ;;
+  upload)
+    gnome-extensions upload messagingmenu\@lauinger-clan.de.shell-extension.zip
+    ;;
+  *)
+  echo "Usage: $0 {zip|pack|install|upload}"
+    exit 1
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ gnome-extensions pack --podir=../po/ --out-dir=../ --extra-source=\ui --extra-so
 cd ..
 mv messagingmenu@lauinger-clan.de.shell-extension.zip messagingmenu@lauinger-clan.de.zip
 
-if [ "$1" = "zip" ]; then
+if [ "$1" = "zip" ] || [ "$1" = "pack" ]; then
    echo "Extension zip created ..."
 else
    gnome-extensions install messagingmenu\@lauinger-clan.de.zip --force

--- a/messagingmenu@lauinger-clan.de/extension.js
+++ b/messagingmenu@lauinger-clan.de/extension.js
@@ -1,8 +1,4 @@
-/**
- * Messaging Menu - A Messaging Menu for the Gnome Shell
- * Copyright (C) 2012 Andreas Wilhelm
- * See LICENSE.txt for details
- */
+"use strict";
 
 import Shell from "gi://Shell";
 import Gio from "gi://Gio";

--- a/messagingmenu@lauinger-clan.de/extension.js
+++ b/messagingmenu@lauinger-clan.de/extension.js
@@ -455,7 +455,7 @@ export default class MessagingMenu extends Extension {
         } catch (err) {
             /* If the extension is broken I don't want to break everything.
              * We just catch the extension, print it and go on */
-            console.error(err, "messagingmenu");
+            this.getLogger().error(err);
         }
     }
 

--- a/messagingmenu@lauinger-clan.de/metadata.json
+++ b/messagingmenu@lauinger-clan.de/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["45", "46", "47", "48"],
+    "shell-version": ["48", "49"],
     "uuid": "messagingmenu@lauinger-clan.de",
     "name": "Messaging Menu",
     "original-author": "sinisterstuf",
@@ -11,5 +11,5 @@
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "48.8"
+    "version-name": "49.0"
 }

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 import Gdk from "gi://Gdk";
 import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -13,11 +13,18 @@ const AppChooser = GObject.registerClass(
     class AppChooser extends Adw.Window {
         constructor(params = {}) {
             super(params);
-            let adwtoolbarview = new Adw.ToolbarView();
-            let adwheaderbar = new Adw.HeaderBar();
+            const adwtoolbarview = new Adw.ToolbarView();
+            const adwheaderbar = new Adw.HeaderBar();
             adwtoolbarview.add_top_bar(adwheaderbar);
             this.set_content(adwtoolbarview);
-            let scrolledwindow = new Gtk.ScrolledWindow();
+
+            const searchEntry = new Gtk.SearchEntry({
+                placeholder_text: _("Search..."),
+                hexpand: true,
+            });
+            adwheaderbar.set_title_widget(searchEntry);
+
+            const scrolledwindow = new Gtk.ScrolledWindow();
             adwtoolbarview.set_content(scrolledwindow);
             this.listBox = new Gtk.ListBox({
                 selection_mode: Gtk.SelectionMode.SINGLE,
@@ -37,18 +44,26 @@ const AppChooser = GObject.registerClass(
                     const nameB = b.get_display_name().toLowerCase();
                     return nameA.localeCompare(nameB);
                 });
-
             for (const app of apps) {
                 if (app.should_show() === false) continue;
                 const row = new Adw.ActionRow();
                 row.title = app.get_display_name();
                 row.subtitle = app.get_id();
+                row._searchableText = app.get_display_name().toLowerCase() + " " + app.get_name().toLowerCase();
                 row.subtitleLines = 1;
                 const icon = new Gtk.Image({ gicon: app.get_icon() });
                 row.add_prefix(icon);
                 this.listBox.append(row);
             }
-
+            const filterFunc = (row) => {
+                const filterText = searchEntry.get_text().toLowerCase();
+                if (!filterText) return true;
+                return row._searchableText.includes(filterText);
+            };
+            this.listBox.set_filter_func(filterFunc);
+            searchEntry.connect("search-changed", () => {
+                this.listBox.invalidate_filter();
+            });
             this.cancelBtn.connect("clicked", () => {
                 this.close();
             });

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -280,7 +280,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         entry_add.activatable_widget = buttonfilechooser;
         buttonfilechooser.connect("clicked", async () => {
             const errorLog = (...args) => {
-                this.getlogger().error("Error:", ...args);
+                this.getLogger().error("Error:", ...args);
             };
             const handleError = (error) => {
                 errorLog(error);

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -80,9 +80,7 @@ const AppChooser = GObject.registerClass(
 export default class AdwPrefs extends ExtensionPreferences {
     _addMenuChangeDesc(cmb_add, group_add) {
         if (cmb_add.get_selected() < 3) {
-            group_add.set_description(
-                _("Name of .desktop files without .desktop ending")
-            );
+            group_add.set_description(_("Name of .desktop files without .desktop ending"));
         } else {
             group_add.set_description(_("Notifier title"));
         }
@@ -120,13 +118,8 @@ export default class AdwPrefs extends ExtensionPreferences {
                 console.log("_addMenu did not find get_active_id");
         }
         let valuesettings = this.getSettings().get_string(strsettings);
-        if (
-            !valuesettings.toLowerCase().includes(entry_add.text.toLowerCase())
-        ) {
-            this.getSettings().set_string(
-                strsettings,
-                valuesettings + ";" + entry_add.text
-            );
+        if (!valuesettings.toLowerCase().includes(entry_add.text.toLowerCase())) {
+            this.getSettings().set_string(strsettings, valuesettings + ";" + entry_add.text);
             const group = builder.get_object(strgroup);
             const adwrow = new Adw.ActionRow({ title: entry_add.text });
             group.add(adwrow);
@@ -135,10 +128,7 @@ export default class AdwPrefs extends ExtensionPreferences {
     }
 
     _onColorChanged(color_setting_button) {
-        this.getSettings().set_string(
-            "color-rgba",
-            color_setting_button.get_rgba().to_string()
-        );
+        this.getSettings().set_string("color-rgba", color_setting_button.get_rgba().to_string());
     }
 
     _overtakeScanRow(builder, adwrow) {
@@ -173,10 +163,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         const button_add = new Gtk.Button({ label: _("Add") });
         button_add.set_css_classes(["suggested-action"]);
         button_add.valign = Gtk.Align.CENTER;
-        button_add.connect(
-            "clicked",
-            this._overtakeScanRow.bind(this, builder, adwrow)
-        );
+        button_add.connect("clicked", this._overtakeScanRow.bind(this, builder, adwrow));
         adwrow.add_suffix(button_add);
     }
 
@@ -187,19 +174,14 @@ export default class AdwPrefs extends ExtensionPreferences {
         const adwrow = builder.get_object("messagingmenu_row_add3");
         const compatibleemails = settings.get_string("compatible-emails");
         const compatiblechats = settings.get_string("compatible-chats");
-        const compatiblehiddenemailnotifiers = settings.get_string(
-            "compatible-hidden-email-notifiers"
-        );
+        const compatiblehiddenemailnotifiers = settings.get_string("compatible-hidden-email-notifiers");
         let count = 0;
         for (const app of apps) {
             const deskappinfo = Gio.DesktopAppInfo.new(app.get_id());
             let categories = deskappinfo.get_categories();
             let settingsapp = app.get_id().slice(0, -8); // Remove .desktop suffix
             if (categories !== null && categories.includes("Email")) {
-                if (
-                    !compatibleemails.includes(settingsapp) &&
-                    !compatiblehiddenemailnotifiers.includes(settingsapp)
-                ) {
+                if (!compatibleemails.includes(settingsapp) && !compatiblehiddenemailnotifiers.includes(settingsapp)) {
                     this._addScanRow(builder, app, 0);
                     console.log("Email app found:", app.get_id());
                     count += 1;
@@ -214,75 +196,62 @@ export default class AdwPrefs extends ExtensionPreferences {
             }
         }
         adwrow.set_title(_("Scan finished"));
-        adwrow.set_subtitle(
-            ngettext("Scan found %d app", "Scan found %d apps", count).format(
-                count
-            )
-        );
+        adwrow.set_subtitle(ngettext("Scan found %d app", "Scan found %d apps", count).format(count));
+    }
+
+    _resetSettings(settings, strKey) {
+        if (strKey === "all") {
+            // List all keys you want to reset
+            const keys = [
+                "compatible-chats",
+                "compatible-mblogs",
+                "compatible-emails",
+                "compatible-hidden-email-notifiers",
+                "compatible-hidden-mblog-notifiers",
+                "icon-size",
+                "notify-email",
+                "notify-chat",
+                "notify-mblogging",
+                "color-rgba",
+            ];
+            keys.forEach((key) => {
+                if (settings.is_writable(key)) {
+                    settings.reset(key);
+                }
+            });
+        } else if (settings.is_writable(strKey)) {
+            settings.reset(strKey);
+        }
     }
 
     _page1(builder, settings, myAppChooser) {
         const email_setting_switch = builder.get_object("messagingmenu_row1");
         email_setting_switch.set_tooltip_text(_("Toggle email notification"));
-        settings.bind(
-            "notify-email",
-            email_setting_switch,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        settings.bind("notify-email", email_setting_switch, "active", Gio.SettingsBindFlags.DEFAULT);
         const chat_setting_switch = builder.get_object("messagingmenu_row2");
         chat_setting_switch.set_tooltip_text(_("Toggle chat notification"));
-        settings.bind(
-            "notify-chat",
-            chat_setting_switch,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT
-        );
-        const mblogging_setting_switch =
-            builder.get_object("messagingmenu_row3");
-        mblogging_setting_switch.set_tooltip_text(
-            _("Toggle micro blogging notification")
-        );
-        settings.bind(
-            "notify-mblogging",
-            mblogging_setting_switch,
-            "active",
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        settings.bind("notify-chat", chat_setting_switch, "active", Gio.SettingsBindFlags.DEFAULT);
+        const mblogging_setting_switch = builder.get_object("messagingmenu_row3");
+        mblogging_setting_switch.set_tooltip_text(_("Toggle micro blogging notification"));
+        settings.bind("notify-mblogging", mblogging_setting_switch, "active", Gio.SettingsBindFlags.DEFAULT);
         const color_setting_button = builder.get_object("color_setting_button");
         color_setting_button.set_tooltip_text(_("Notification Color RGB"));
         const mycolor = new Gdk.RGBA();
         mycolor.parse(this.getSettings().get_string("color-rgba"));
         color_setting_button.set_rgba(mycolor);
-        color_setting_button.connect(
-            "color-set",
-            this._onColorChanged.bind(this, color_setting_button)
-        );
+        color_setting_button.connect("color-set", this._onColorChanged.bind(this, color_setting_button));
         const row5 = builder.get_object("messagingmenu_row5");
-        settings.bind(
-            "icon-size",
-            row5,
-            "value",
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        settings.bind("icon-size", row5, "value", Gio.SettingsBindFlags.DEFAULT);
 
         const group_add = builder.get_object("messagingmenu_group_add");
         const cmb_add = builder.get_object("messagingmenu_cmb_add");
         cmb_add.set_selected(0);
-        cmb_add.connect(
-            "notify",
-            this._addMenuChangeDesc.bind(this, cmb_add, group_add)
-        );
+        cmb_add.connect("notify", this._addMenuChangeDesc.bind(this, cmb_add, group_add));
         const button_add = builder.get_object("button_add_menu_add");
         button_add.set_css_classes(["suggested-action"]);
         const entry_add = builder.get_object("messagingmenu_row_add2");
-        button_add.connect(
-            "clicked",
-            this._addMenu.bind(this, cmb_add, entry_add, builder)
-        );
-        entry_add.set_tooltip_text(
-            _("Usually located in '/usr/share/applications'")
-        );
+        button_add.connect("clicked", this._addMenu.bind(this, cmb_add, entry_add, builder));
+        entry_add.set_tooltip_text(_("Usually located in '/usr/share/applications'"));
         const buttonfilechooser = new Gtk.Button({
             label: _("..."),
             valign: Gtk.Align.CENTER,
@@ -297,14 +266,9 @@ export default class AdwPrefs extends ExtensionPreferences {
         });
         const button_scan = builder.get_object("button_add_menu_scan");
         button_scan.set_tooltip_text(
-            _(
-                "Scan installed applications for compatible Email and Chat apps (Categories: Email, Chat)"
-            )
+            _("Scan installed applications for compatible Email and Chat apps (Categories: Email, Chat)")
         );
-        button_scan.connect(
-            "clicked",
-            this._scanApps.bind(this, builder, settings)
-        );
+        button_scan.connect("clicked", this._scanApps.bind(this, builder, settings));
     }
 
     _addAppIcon(adwrow, appname) {
@@ -329,38 +293,23 @@ export default class AdwPrefs extends ExtensionPreferences {
     }
 
     _pages(builder, settings) {
-        let apps = settings
-            .get_string("compatible-emails")
-            .split(";")
-            .sort(Intl.Collator().compare);
+        let apps = settings.get_string("compatible-emails").split(";").sort(Intl.Collator().compare);
         let group = builder.get_object("messagingmenu_group_email");
         this._fillgroup(group, apps);
 
-        apps = settings
-            .get_string("compatible-chats")
-            .split(";")
-            .sort(Intl.Collator().compare);
+        apps = settings.get_string("compatible-chats").split(";").sort(Intl.Collator().compare);
         group = builder.get_object("messagingmenu_group_chat");
         this._fillgroup(group, apps);
 
-        apps = settings
-            .get_string("compatible-mblogs")
-            .split(";")
-            .sort(Intl.Collator().compare);
+        apps = settings.get_string("compatible-mblogs").split(";").sort(Intl.Collator().compare);
         group = builder.get_object("messagingmenu_group_mblog");
         this._fillgroup(group, apps);
 
-        apps = settings
-            .get_string("compatible-hidden-email-notifiers")
-            .split(";")
-            .sort(Intl.Collator().compare);
+        apps = settings.get_string("compatible-hidden-email-notifiers").split(";").sort(Intl.Collator().compare);
         group = builder.get_object("messagingmenu_group_emailnotifiers");
         this._fillgroup(group, apps);
 
-        apps = settings
-            .get_string("compatible-hidden-mblog-notifiers")
-            .split(";")
-            .sort(Intl.Collator().compare);
+        apps = settings.get_string("compatible-hidden-mblog-notifiers").split(";").sort(Intl.Collator().compare);
         group = builder.get_object("messagingmenu_group_mblognotifiers");
         this._fillgroup(group, apps);
     }

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -9,15 +9,6 @@ import {
     ngettext,
 } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
-const errorLog = (...args) => {
-    console.error("[MessagingMenu]", "Error:", ...args);
-};
-
-const handleError = (error) => {
-    errorLog(error);
-    return null;
-};
-
 const AppChooser = GObject.registerClass(
     class AppChooser extends Adw.Window {
         constructor(params = {}) {
@@ -259,6 +250,13 @@ export default class AdwPrefs extends ExtensionPreferences {
         entry_add.add_suffix(buttonfilechooser);
         entry_add.activatable_widget = buttonfilechooser;
         buttonfilechooser.connect("clicked", async () => {
+            const errorLog = (...args) => {
+                this.getlogger().error("Error:", ...args);
+            };
+            const handleError = (error) => {
+                errorLog(error);
+                return null;
+            };
             const appRow = await myAppChooser.showChooser().catch(handleError);
             if (appRow !== null) {
                 entry_add.set_text(appRow.subtitle.replace(".desktop", ""));

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:23+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -32,15 +32,19 @@ msgstr "Kontakte"
 msgid "Settings"
 msgstr "Instellings"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Kies"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Kanselleer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Kanselleer"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Naam van .desktop-lêers sonder .desktop-einde"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Kennisgewing titel"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Herstel Instellings"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-pos"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Klets"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-pos kennisgewer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikroblog kennisgewer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Voeg by"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Skakel e-pos kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Skakel klets kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Skakel mikroblog kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kennisgewing Kleur (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Gewoonlik geleë in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Kies toepassing"
 

--- a/po/af.po
+++ b/po/af.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:23+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Skryf Nuwe Boodskap"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Instellings"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Kies"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Kanselleer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Kanselleer"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Naam van .desktop-lêers sonder .desktop-einde"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Kennisgewing titel"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Herstel Instellings"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-pos"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Klets"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-pos kennisgewer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikroblog kennisgewer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Voeg by"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Skakel e-pos kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Skakel klets kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Skakel mikroblog kennisgewing aan/af"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kennisgewing Kleur (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Gewoonlik geleë in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Kies toepassing"
 

--- a/po/cz.po
+++ b/po/cz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:23+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Czech\n"
@@ -32,15 +32,19 @@ msgstr "Kontakty"
 msgid "Settings"
 msgstr "Nastavení"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Vybrat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,67 +52,67 @@ msgstr "Zrušit"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Název souborů .desktop bez koncovky .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Název upozornění"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Obnovit nastavení"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Upozornění na email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Upozornění na micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Přidat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
@@ -116,38 +120,38 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Přepnout upozornění na email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Přepnout upozornění na chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Přepnout upozornění na micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Barva upozornění (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Obvykle se nachází v '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Vybrat aplikaci"
 

--- a/po/cz.po
+++ b/po/cz.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:23+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Czech\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Vytvořit novou zprávu"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kontakty"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Nastavení"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Vybrat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,59 +48,67 @@ msgstr "Zrušit"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Název souborů .desktop bez koncovky .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Název upozornění"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Obnovit nastavení"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Upozornění na email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Upozornění na micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Přidat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
@@ -108,38 +116,38 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Přepnout upozornění na email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Přepnout upozornění na chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Přepnout upozornění na micro-blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Barva upozornění (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Obvykle se nachází v '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Vybrat aplikaci"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
-"PO-Revision-Date: 2025-06-24 18:16+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
+"PO-Revision-Date: 2025-07-26 12:39+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -32,15 +32,19 @@ msgstr "Kontakte"
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr "Suchen..."
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Auswählen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,99 +52,99 @@ msgstr "Abbrechen"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Name der .desktop Datei ohne Dateiendung .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Benachrichtigungstitel"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Einstellungen zurücksetzen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr "Gefunden durch Scannen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-Post"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Epost-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikroblog-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr "Scan beendet"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] "Scan hat %d Applikation gefunden"
 msgstr[1] "Scan hat %d Applikationen gefunden"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Umschalter Epost-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Umschalter Chat-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Umschalter Mikroblog-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Benachrichtigungsfarbe RGB"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Befinden sich normalerweise in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
@@ -148,7 +152,7 @@ msgstr ""
 "Scannen Sie installierte Anwendungen auf kompatible E-Mail- und Chat-"
 "Anwendungen (Kategorien: E-Mail, Chat)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "App auswählen"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
-"PO-Revision-Date: 2025-06-04 18:30+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"PO-Revision-Date: 2025-06-24 18:16+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Neue Nachricht erstellen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kontakte"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Auswählen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,91 +48,99 @@ msgstr "Abbrechen"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Name der .desktop Datei ohne Dateiendung .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Benachrichtigungstitel"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Einstellungen zurücksetzen"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr "Alle Einstellungen auf Standardwerte zurücksetzen"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr "Gefunden durch Scannen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-Post"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Epost-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikroblog-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr "Scan beendet"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] "Scan hat %d Applikation gefunden"
 msgstr[1] "Scan hat %d Applikationen gefunden"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Umschalter Epost-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Umschalter Chat-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Umschalter Mikroblog-Benachrichtigung"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Benachrichtigungsfarbe RGB"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Befinden sich normalerweise in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
@@ -140,7 +148,7 @@ msgstr ""
 "Scannen Sie installierte Anwendungen auf kompatible E-Mail- und Chat-"
 "Anwendungen (Kategorien: E-Mail, Chat)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "App auswählen"
 
@@ -263,6 +271,9 @@ msgstr "Symbolgrösse"
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:56
 msgid "Size of the app icons in the menu"
 msgstr "Grösse der Applikations-Symbole im Menü"
+
+#~ msgid "Reset"
+#~ msgstr "Zurücksetzen"
 
 #~ msgid "Notification Color (Hex):"
 #~ msgstr "Benachrichtigungsfarbe (Hex):"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Spanish\n"
@@ -32,15 +32,19 @@ msgstr "Contactos"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Seleccionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Cancelar"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nombre de archivos .desktop sin la terminación .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Título del Notificador"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Restablecer ajustes"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Correo Electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificador de Correo Electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificador de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Agregar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Alternar notificación de correo electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Alternar notificación de chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Alternar notificación de microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Color de la Notificación (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Normalmente ubicado en '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Seleccionar aplicación"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Spanish\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Crear un Nuevo Mensaje"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Contactos"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Ajustes"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Seleccionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Cancelar"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nombre de archivos .desktop sin la terminación .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Título del Notificador"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Restablecer ajustes"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Correo Electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificador de Correo Electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificador de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Agregar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Alternar notificación de correo electrónico"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Alternar notificación de chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Alternar notificación de microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Color de la Notificación (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Normalmente ubicado en '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Seleccionar aplicación"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: French\n"
@@ -32,15 +32,19 @@ msgstr "Contacts"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Sélectionner"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Annuler"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Annuler"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nom des fichiers .desktop sans l'extension .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titre de la Notification"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Réinitialiser les paramètres"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notification par Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notification de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Ajouter"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Basculer vers la notification par courrier électronique"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Afficher la notification de la discussion en ligne"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Basculer la notification de microblogage"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Couleur de la Notification (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Généralement situé dans '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Sélectionner l'application"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: French\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Composer un Nouveau Message"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Contacts"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Paramètres"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Sélectionner"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Annuler"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Annuler"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nom des fichiers .desktop sans l'extension .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titre de la Notification"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Réinitialiser les paramètres"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notification par Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notification de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Ajouter"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Basculer vers la notification par courrier électronique"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Afficher la notification de la discussion en ligne"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Basculer la notification de microblogage"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Couleur de la Notification (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Généralement situé dans '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Sélectionner l'application"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Hungarian\n"
@@ -32,15 +32,19 @@ msgstr "Kapcsolatok"
 msgid "Settings"
 msgstr "Beállítások"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Mégse"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Mégse"
 msgid "Name of .desktop files without .desktop ending"
 msgstr ".desktop fájlok neve .desktop végződés nélkül"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Értesítési cím"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Beállítások visszaállítása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikro-blogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Email értesítő"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikro-blogging értesítő"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Email értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Chat értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Mikro-blogging értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Értesítési szín (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Általában a '/usr/share/applications' helyen található"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Alkalmazás kiválasztása"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Hungarian\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Új üzenet írása"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kapcsolatok"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Beállítások"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Kiválasztás"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Mégse"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Mégse"
 msgid "Name of .desktop files without .desktop ending"
 msgstr ".desktop fájlok neve .desktop végződés nélkül"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Értesítési cím"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Beállítások visszaállítása"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikro-blogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Email értesítő"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikro-blogging értesítő"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Hozzáadás"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Email értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Chat értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Mikro-blogging értesítés be-/kikapcsolása"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Értesítési szín (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Általában a '/usr/share/applications' helyen található"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Alkalmazás kiválasztása"
 

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Italian\n"
@@ -33,15 +33,19 @@ msgstr "Contatti"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Seleziona"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Annulla"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -49,105 +53,105 @@ msgstr "Annulla"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nome dei file .desktop senza estensione .desktop alla fine"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titolo del Notificatore"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Ripristina impostazioni"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificatore di Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificatore di Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Aggiungi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Attiva/disattiva notifica e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Attiva/disattiva notifica chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Attiva/disattiva notifica micro blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Colore della Notifica (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Di solito si trova in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Seleziona app"
 

--- a/po/it.po
+++ b/po/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:25+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Italian\n"
@@ -19,29 +19,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Componi un Nuovo Messaggio"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Contatti"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Seleziona"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Annulla"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -49,97 +49,105 @@ msgstr "Annulla"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nome dei file .desktop senza estensione .desktop alla fine"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titolo del Notificatore"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Ripristina impostazioni"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificatore di Email"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificatore di Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Aggiungi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Attiva/disattiva notifica e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Attiva/disattiva notifica chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Attiva/disattiva notifica micro blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Colore della Notifica (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Di solito si trova in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Seleziona app"
 

--- a/po/messagingmenu.pot
+++ b/po/messagingmenu.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,15 +32,19 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr ""
 msgid "Name of .desktop files without .desktop ending"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr ""
 

--- a/po/messagingmenu.pot
+++ b/po/messagingmenu.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr ""
 msgid "Name of .desktop files without .desktop ending"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -32,15 +32,19 @@ msgstr "Contactpersonen"
 msgid "Settings"
 msgstr "Instellingen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Selecteer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Annuleren"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "De naam van .desktopbestanden, zonder de .desktop-extensie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titel van de melding"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Instellingen herstellen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-mailnotificatie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Microblogging-notificatie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Toevoegen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "E-mailmelding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Chatmelding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Microblogging-melding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kleur van de melding (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Meestal te vinden in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Selecteer app"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Bericht opstellen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Contactpersonen"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Instellingen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Selecteer"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Annuleren"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "De naam van .desktopbestanden, zonder de .desktop-extensie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Titel van de melding"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Instellingen herstellen"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-mailnotificatie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Microblogging-notificatie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Toevoegen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "E-mailmelding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Chatmelding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Microblogging-melding in-/uitschakelen"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kleur van de melding (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Meestal te vinden in '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Selecteer app"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Polish\n"
@@ -34,15 +34,19 @@ msgstr "Kontakty"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Wybierz"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -50,67 +54,67 @@ msgstr "Anuluj"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nazwa plików .desktop bez końcówki .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Tytuł powiadomienia"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Przywróć ustawienia"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Czat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblogowanie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Powiadomienie e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Powiadomienie mikroblogów"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Dodaj"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
@@ -118,38 +122,38 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Włącz/wyłącz powiadomienia e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Włącz/wyłącz powiadomienia czatu"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Włącz/wyłącz powiadomienia mikroblogów"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kolor powiadomienia (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Zazwyczaj znajduje się w '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Wybierz aplikację"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Polish\n"
@@ -20,29 +20,29 @@ msgstr ""
 "X-Generator: Poedit 3.6\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Napisz nową wiadomość"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kontakty"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Wybierz"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -50,59 +50,67 @@ msgstr "Anuluj"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nazwa plików .desktop bez końcówki .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Tytuł powiadomienia"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Przywróć ustawienia"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Czat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikroblogowanie"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Powiadomienie e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Powiadomienie mikroblogów"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Dodaj"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
@@ -110,38 +118,38 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Włącz/wyłącz powiadomienia e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Włącz/wyłącz powiadomienia czatu"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Włącz/wyłącz powiadomienia mikroblogów"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Kolor powiadomienia (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Zazwyczaj znajduje się w '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Wybierz aplikację"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -32,15 +32,19 @@ msgstr "Contatos"
 msgid "Settings"
 msgstr "Configurações"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Selecionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,105 +52,105 @@ msgstr "Cancelar"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nome dos arquivos .desktop sem a terminação .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Título do Notificador"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Redefinir configurações"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificador de E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificador de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Adicionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Alternar notificação de e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Alternar notificação de chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Alternar notificação de microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Cor da Notificação (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Normalmente localizado em '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Selecionar aplicativo"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:26+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Brazilian Portuguese\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Escrever Nova Mensagem"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Contatos"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Configurações"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Selecionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,97 +48,105 @@ msgstr "Cancelar"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Nome dos arquivos .desktop sem a terminação .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Título do Notificador"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Redefinir configurações"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Notificador de E-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Notificador de Microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Adicionar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Alternar notificação de e-mail"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Alternar notificação de chat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Alternar notificação de microblogging"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Cor da Notificação (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Normalmente localizado em '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Selecionar aplicativo"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:27+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Russian\n"
@@ -33,15 +33,19 @@ msgstr "Контакты"
 msgid "Settings"
 msgstr "Настройки"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Выбрать"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "Отмена"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -49,105 +53,105 @@ msgstr "Отмена"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Имя файлов .desktop без окончания .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Заголовок уведомления"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Сбросить настройки"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Электронная почта"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Чат"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Микроблог"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Уведомление по электронной почте"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Уведомление микроблога"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Добавить"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "Переключить уведомление по электронной почте"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Переключить уведомление чата"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Переключить уведомление микроблога"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Цвет уведомления (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Обычно находится в '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Выбрать приложение"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:27+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Russian\n"
@@ -19,29 +19,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Создать Новое Сообщение"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Контакты"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Настройки"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Выбрать"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "Отмена"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -49,97 +49,105 @@ msgstr "Отмена"
 msgid "Name of .desktop files without .desktop ending"
 msgstr "Имя файлов .desktop без окончания .desktop"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Заголовок уведомления"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Сбросить настройки"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "Электронная почта"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Чат"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Микроблог"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "Уведомление по электронной почте"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Уведомление микроблога"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Добавить"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 msgstr[1] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "Переключить уведомление по электронной почте"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Переключить уведомление чата"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Переключить уведомление микроблога"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Цвет уведомления (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Обычно находится в '/usr/share/applications'"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Выбрать приложение"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-24 18:15+0200\n"
+"POT-Creation-Date: 2025-07-26 12:32+0200\n"
 "PO-Revision-Date: 2025-06-01 19:27+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Turkish <>\n"
@@ -32,15 +32,19 @@ msgstr "Kişiler"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:27
+#: messagingmenu@lauinger-clan.de/prefs.js:22
+msgid "Search..."
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:34
 msgid "Select"
 msgstr "Seç"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:30
+#: messagingmenu@lauinger-clan.de/prefs.js:37
 msgid "Cancel"
 msgstr "İptal"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:74
+#: messagingmenu@lauinger-clan.de/prefs.js:90
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,104 +52,104 @@ msgstr "İptal"
 msgid "Name of .desktop files without .desktop ending"
 msgstr ".desktop uzantısı olmadan .desktop dosyalarının adı"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:76
+#: messagingmenu@lauinger-clan.de/prefs.js:92
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Bildirim başlığı"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:133
+#: messagingmenu@lauinger-clan.de/prefs.js:149
 msgid "Reset Settings"
 msgstr "Ayarları Sıfırla"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:139
+#: messagingmenu@lauinger-clan.de/prefs.js:155
 msgid "Reset all settings to default values"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:172
+#: messagingmenu@lauinger-clan.de/prefs.js:188
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:174
+#: messagingmenu@lauinger-clan.de/prefs.js:190
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-posta"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:175
+#: messagingmenu@lauinger-clan.de/prefs.js:191
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Sohbet"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:176
+#: messagingmenu@lauinger-clan.de/prefs.js:192
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikro blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:177
+#: messagingmenu@lauinger-clan.de/prefs.js:193
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-posta bildirimi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:178
+#: messagingmenu@lauinger-clan.de/prefs.js:194
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikro blog bildirimi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:183
+#: messagingmenu@lauinger-clan.de/prefs.js:199
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Ekle"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:218
+#: messagingmenu@lauinger-clan.de/prefs.js:234
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:219
+#: messagingmenu@lauinger-clan.de/prefs.js:235
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:249
+#: messagingmenu@lauinger-clan.de/prefs.js:265
 msgid "Toggle email notification"
 msgstr "E-posta bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:252
+#: messagingmenu@lauinger-clan.de/prefs.js:268
 msgid "Toggle chat notification"
 msgstr "Sohbet bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:255
+#: messagingmenu@lauinger-clan.de/prefs.js:271
 msgid "Toggle micro blogging notification"
 msgstr "Mikro blog bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:258
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Bildirim Rengi (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:274
+#: messagingmenu@lauinger-clan.de/prefs.js:290
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Genellikle '/usr/share/applications' konumunda bulunur"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:276
+#: messagingmenu@lauinger-clan.de/prefs.js:292
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:296
+#: messagingmenu@lauinger-clan.de/prefs.js:312
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:352
+#: messagingmenu@lauinger-clan.de/prefs.js:368
 msgid "Select app"
 msgstr "Uygulama seç"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Messaging Menu Version 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-04 18:29+0200\n"
+"POT-Creation-Date: 2025-06-24 18:15+0200\n"
 "PO-Revision-Date: 2025-06-01 19:27+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: Turkish <>\n"
@@ -18,29 +18,29 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.6\n"
 
-#: messagingmenu@lauinger-clan.de/extension.js:89
+#: messagingmenu@lauinger-clan.de/extension.js:80
 msgid "Compose New Message"
 msgstr "Yeni İleti Oluştur"
 
-#: messagingmenu@lauinger-clan.de/extension.js:90
+#: messagingmenu@lauinger-clan.de/extension.js:81
 msgid "Contacts"
 msgstr "Kişiler"
 
-#: messagingmenu@lauinger-clan.de/extension.js:319
+#: messagingmenu@lauinger-clan.de/extension.js:245
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:5
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:9
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:36
+#: messagingmenu@lauinger-clan.de/prefs.js:27
 msgid "Select"
 msgstr "Seç"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:39
+#: messagingmenu@lauinger-clan.de/prefs.js:30
 msgid "Cancel"
 msgstr "İptal"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:78
+#: messagingmenu@lauinger-clan.de/prefs.js:74
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:55
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:105
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:116
@@ -48,96 +48,104 @@ msgstr "İptal"
 msgid "Name of .desktop files without .desktop ending"
 msgstr ".desktop uzantısı olmadan .desktop dosyalarının adı"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:81
+#: messagingmenu@lauinger-clan.de/prefs.js:76
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:138
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:144
 msgid "Notifier title"
 msgstr "Bildirim başlığı"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:156
+#: messagingmenu@lauinger-clan.de/prefs.js:133
+msgid "Reset Settings"
+msgstr "Ayarları Sıfırla"
+
+#: messagingmenu@lauinger-clan.de/prefs.js:139
+msgid "Reset all settings to default values"
+msgstr ""
+
+#: messagingmenu@lauinger-clan.de/prefs.js:172
 msgid "Found by scan"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:158
+#: messagingmenu@lauinger-clan.de/prefs.js:174
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:62
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:100
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:104
 msgid "Email"
 msgstr "E-posta"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:159
+#: messagingmenu@lauinger-clan.de/prefs.js:175
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:63
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:111
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:115
 msgid "Chat"
 msgstr "Sohbet"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:160
+#: messagingmenu@lauinger-clan.de/prefs.js:176
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:64
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:122
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:126
 msgid "Micro blogging"
 msgstr "Mikro blog"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:161
+#: messagingmenu@lauinger-clan.de/prefs.js:177
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:65
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:137
 msgid "Email notifier"
 msgstr "E-posta bildirimi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:162
+#: messagingmenu@lauinger-clan.de/prefs.js:178
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:66
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:143
 msgid "Micro blogging notifier"
 msgstr "Mikro blog bildirimi"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:167
+#: messagingmenu@lauinger-clan.de/prefs.js:183
 #: messagingmenu@lauinger-clan.de/ui/prefs.ui:89
 msgid "Add"
 msgstr "Ekle"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:210
+#: messagingmenu@lauinger-clan.de/prefs.js:218
 msgid "Scan finished"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:212
+#: messagingmenu@lauinger-clan.de/prefs.js:219
 #, javascript-format
 msgid "Scan found %d app"
 msgid_plural "Scan found %d apps"
 msgstr[0] ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:220
+#: messagingmenu@lauinger-clan.de/prefs.js:249
 msgid "Toggle email notification"
 msgstr "E-posta bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:228
+#: messagingmenu@lauinger-clan.de/prefs.js:252
 msgid "Toggle chat notification"
 msgstr "Sohbet bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:238
+#: messagingmenu@lauinger-clan.de/prefs.js:255
 msgid "Toggle micro blogging notification"
 msgstr "Mikro blog bildirimini aç/kapat"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:247
+#: messagingmenu@lauinger-clan.de/prefs.js:258
 #: messagingmenu@lauinger-clan.de/schemas/org.gnome.shell.extensions.messagingmenu.gschema.xml:25
 msgid "Notification Color RGB"
 msgstr "Bildirim Rengi (RGB)"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:278
+#: messagingmenu@lauinger-clan.de/prefs.js:274
 msgid "Usually located in '/usr/share/applications'"
 msgstr "Genellikle '/usr/share/applications' konumunda bulunur"
 
-#: messagingmenu@lauinger-clan.de/prefs.js:281
+#: messagingmenu@lauinger-clan.de/prefs.js:276
 msgid "..."
 msgstr "..."
 
-#: messagingmenu@lauinger-clan.de/prefs.js:295
+#: messagingmenu@lauinger-clan.de/prefs.js:296
 msgid ""
 "Scan installed applications for compatible Email and Chat apps (Categories: "
 "Email, Chat)"
 msgstr ""
 
-#: messagingmenu@lauinger-clan.de/prefs.js:370
+#: messagingmenu@lauinger-clan.de/prefs.js:352
 msgid "Select app"
 msgstr "Uygulama seç"
 


### PR DESCRIPTION
This update ensures compatibility with GNOME Shell 49 and provides a settings reset button.

- Aligns the extension with the latest GNOME Shell version.
- Introduces a "Reset Settings" button in the preferences, allowing users to revert to the default configuration.
- Simplifies the preferences code by using the extension's logger and refactors parts of the preference code for maintainability.