### PR TITLE
Updates extension for GNOME Shell 51 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/messagingmenu@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-3.34%20--%2050-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-messagingmenu)
+![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/messagingmenu@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-3.34%20--%2051-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-messagingmenu)
 
 </div>
 

--- a/messagingmenu@lauinger-clan.de/extension.js
+++ b/messagingmenu@lauinger-clan.de/extension.js
@@ -87,13 +87,28 @@ const MessageMenu = GObject.registerClass(
                 this._buildMenuGEARY();
             }
             this._buildMenu(this._extension);
-            this.connect("button-press-event", (actor, event) => {
-                if (event.get_button() === Clutter.BUTTON_MIDDLE) {
-                    this._extension.openPreferences();
-                    this.menu.close();
-                }
-                return Clutter.EVENT_STOP;
+            this._buttonClickGestures();
+        }
+
+        _buttonClickGestures() {
+            // make sure the menu opens on left click, and that middle click opens the preferences
+            this._clickGesture.required_button = Clutter.BUTTON_PRIMARY;
+            const middleClickGesture = new Clutter.ClickGesture({
+                required_button: Clutter.BUTTON_MIDDLE,
             });
+            middleClickGesture.connect("recognize", () => {
+                this.menu.close();
+                this._extension.openPreferences();
+            });
+            this.add_action(middleClickGesture);
+
+            const secondaryClickGesture = new Clutter.ClickGesture({
+                required_button: Clutter.BUTTON_SECONDARY,
+            });
+            secondaryClickGesture.connect("recognize", () => {
+                this.menu.toggle();
+            });
+            this.add_action(secondaryClickGesture);
         }
 
         createMessageMenuItem(app) {

--- a/messagingmenu@lauinger-clan.de/extension.js
+++ b/messagingmenu@lauinger-clan.de/extension.js
@@ -357,12 +357,14 @@ export default class MessagingMenu extends Extension {
             } else if (source.app) {
                 if (this._settings.get_boolean("notify-email")) {
                     newMessage =
+                        newMessage ||
                         this._checkNotifyEmailByID(source) ||
                         this._checkHiddenNotifierMatch(source, this._indicator.compatibleHiddenEmailNotifiers);
                 }
             } else {
                 if (this._settings.get_boolean("notify-email")) {
                     newMessage =
+                        newMessage ||
                         this._checkNotifyEmailByName(source) ||
                         this._checkHiddenNotifierMatch(source, this._indicator.compatibleHiddenEmailNotifiers);
                 }

--- a/messagingmenu@lauinger-clan.de/metadata.json
+++ b/messagingmenu@lauinger-clan.de/metadata.json
@@ -3,7 +3,11 @@
     "gettext-domain": "messagingmenu",
     "description": "A Messaging Menu for the Gnome Shell. All Email and Chat Applications in one Place.",
     "uuid": "messagingmenu@lauinger-clan.de",
-    "shell-version": ["48", "49", "50", "51"],
+    "shell-version": [
+        "49",
+        "50",
+        "51"
+    ],
     "original-author": "sinisterstuf",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-messagingmenu",
     "settings-schema": "org.gnome.shell.extensions.messagingmenu",

--- a/messagingmenu@lauinger-clan.de/metadata.json
+++ b/messagingmenu@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "gettext-domain": "messagingmenu",
     "description": "A Messaging Menu for the Gnome Shell. All Email and Chat Applications in one Place.",
     "uuid": "messagingmenu@lauinger-clan.de",
-    "shell-version": ["48", "49", "50"],
+    "shell-version": ["48", "49", "50", "51"],
     "original-author": "sinisterstuf",
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-messagingmenu",
     "settings-schema": "org.gnome.shell.extensions.messagingmenu",
@@ -13,5 +13,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.4"
+    "version-name": "51.0"
 }

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -80,9 +80,7 @@ const AppChooser = GObject.registerClass(
                     if (close) this.close();
                     resolve(row);
                 };
-                signals.select = this.selectBtn.connect("clicked", () =>
-                    finish(this.listBox.get_selected_row())
-                );
+                signals.select = this.selectBtn.connect("clicked", () => finish(this.listBox.get_selected_row()));
                 signals.cancel = this.cancelBtn.connect("clicked", () => finish(null));
                 signals.close = this.connect("close-request", () => {
                     finish(null, false);
@@ -103,7 +101,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         }
     }
 
-    _addMenu(cmb_add, entry_add, builder) {
+    _addMenu(settings, cmb_add, entry_add, builder) {
         if (entry_add.get_text() === "") {
             this.getLogger().log("_addMenu did not find entry_add text");
             return;
@@ -134,9 +132,9 @@ export default class AdwPrefs extends ExtensionPreferences {
             default:
                 this.getLogger().log("_addMenu did not find get_active_id");
         }
-        const valuesettings = this.getSettings().get_string(strSettings);
+        const valuesettings = settings.get_string(strSettings);
         if (!valuesettings.toLowerCase().includes(entry_add.text.toLowerCase())) {
-            this.getSettings().set_string(strSettings, valuesettings + ";" + entry_add.text);
+            settings.set_string(strSettings, valuesettings + ";" + entry_add.text);
             const group = builder.get_object(strGroup);
             const adwrow = new Adw.ActionRow({ title: entry_add.text });
             group.add(adwrow);
@@ -173,11 +171,11 @@ export default class AdwPrefs extends ExtensionPreferences {
         }
     }
 
-    _onColorChanged(color_setting_button) {
-        this.getSettings().set_string("color-rgba", color_setting_button.get_rgba().to_string());
+    _onColorChanged(settings, color_setting_button) {
+        settings.set_string("color-rgba", color_setting_button.get_rgba().to_string());
     }
 
-    _overtakeScanRow(builder, adwrow) {
+    _overtakeScanRow(builder, settings, adwrow) {
         const group_add = builder.get_object("messagingmenu_group_add");
         const cmb_add = builder.get_object("messagingmenu_cmb_add");
         const entry_add = builder.get_object("messagingmenu_row_add2");
@@ -186,10 +184,10 @@ export default class AdwPrefs extends ExtensionPreferences {
             entry_add.set_text(adwrow.title);
         }
         group_add.remove(adwrow);
-        this._addMenu(cmb_add, entry_add, builder);
+        this._addMenu(settings, cmb_add, entry_add, builder);
     }
 
-    _addScanRow(builder, app, cmbid) {
+    _addScanRow(builder, settings, app, cmbid) {
         const group_add = builder.get_object("messagingmenu_group_add");
         const adwrow = new Adw.ComboRow({
             title: app.get_id().slice(0, -8), // Remove .desktop suffix
@@ -229,7 +227,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             const settingsapp = app.get_id().slice(0, -8); // Remove .desktop suffix
             if (categories !== null && categories.includes("Email")) {
                 if (!compatibleemails.includes(settingsapp) && !compatiblehiddenemailnotifiers.includes(settingsapp)) {
-                    this._addScanRow(builder, app, 0);
+                    this._addScanRow(builder, settings, app, 0);
                     this.getLogger().log("Email app found:", app.get_id());
                     count += 1;
                 }
@@ -280,9 +278,9 @@ export default class AdwPrefs extends ExtensionPreferences {
         settings.bind("notify-mblogging", mblogging_setting_switch, "active", Gio.SettingsBindFlags.DEFAULT);
         const color_setting_button = builder.get_object("color_setting_button");
         const mycolor = new Gdk.RGBA();
-        mycolor.parse(this.getSettings().get_string("color-rgba"));
+        mycolor.parse(settings.get_string("color-rgba"));
         color_setting_button.set_rgba(mycolor);
-        color_setting_button.connect("color-set", this._onColorChanged.bind(this, color_setting_button));
+        color_setting_button.connect("color-set", this._onColorChanged.bind(this, settings, color_setting_button));
         const rowwiggle = builder.get_object("messagingmenu_rowwiggle");
         settings.bind("wiggle-indicator", rowwiggle, "active", Gio.SettingsBindFlags.DEFAULT);
 
@@ -292,7 +290,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         cmb_add.connect("notify", this._addMenuChangeDesc.bind(this, cmb_add, group_add));
         const button_add = builder.get_object("messagingmenu_row_buttonadd");
         const entry_add = builder.get_object("messagingmenu_row_add2");
-        button_add.connect("activated", this._addMenu.bind(this, cmb_add, entry_add, builder));
+        button_add.connect("activated", this._addMenu.bind(this, settings, cmb_add, entry_add, builder));
         const buttonfilechooser = builder.get_object("messagingmenu_row_buttonselectapp");
         buttonfilechooser.connect("activated", async () => {
             const errorLog = (...args) => {
@@ -357,6 +355,7 @@ export default class AdwPrefs extends ExtensionPreferences {
     }
 
     fillPreferencesWindow(window) {
+        window._settings = this.getSettings();
         window.search_enabled = true;
         window.set_default_size(675, 775);
         const builder = Gtk.Builder.new();
@@ -380,8 +379,8 @@ export default class AdwPrefs extends ExtensionPreferences {
         window.add(page4);
         const page5 = builder.get_object("messagingmenu_page_notifiers");
         window.add(page5);
-        this._addResetButton(window, this.getSettings());
-        this._page1(builder, this.getSettings(), myAppChooser);
-        this._pages(builder, this.getSettings());
+        this._addResetButton(window, window._settings);
+        this._page1(builder, window._settings, myAppChooser);
+        this._pages(builder, window._settings);
     }
 }

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -68,18 +68,25 @@ const AppChooser = GObject.registerClass(
             searchEntry.connect("search-changed", () => {
                 this.listBox.invalidate_filter();
             });
-            this.cancelBtn.connect("clicked", () => {
-                this.close();
-            });
         }
 
         showChooser() {
             return new Promise((resolve) => {
-                const signalId = this.selectBtn.connect("clicked", () => {
-                    this.close();
-                    this.selectBtn.disconnect(signalId);
-                    const row = this.listBox.get_selected_row();
+                const signals = {};
+                const finish = (row, close = true) => {
+                    this.selectBtn.disconnect(signals.select);
+                    this.cancelBtn.disconnect(signals.cancel);
+                    this.disconnect(signals.close);
+                    if (close) this.close();
                     resolve(row);
+                };
+                signals.select = this.selectBtn.connect("clicked", () =>
+                    finish(this.listBox.get_selected_row())
+                );
+                signals.cancel = this.cancelBtn.connect("clicked", () => finish(null));
+                signals.close = this.connect("close-request", () => {
+                    finish(null, false);
+                    return false;
                 });
                 this.present();
             });
@@ -252,6 +259,7 @@ export default class AdwPrefs extends ExtensionPreferences {
                 "notify-chat",
                 "notify-mblogging",
                 "color-rgba",
+                "wiggle-indicator",
             ];
             for (const key of keys) {
                 if (settings.is_writable(key)) {

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -234,7 +234,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             }
             if (categories !== null && categories.includes("Chat")) {
                 if (!compatiblechats.includes(settingsapp)) {
-                    this._addScanRow(builder, app, 1);
+                    this._addScanRow(builder, settings, app, 1);
                     this.getLogger().log("Chat app found:", app.get_id());
                     count += 1;
                 }

--- a/messagingmenu@lauinger-clan.de/prefs.js
+++ b/messagingmenu@lauinger-clan.de/prefs.js
@@ -207,7 +207,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         const button_add = new Gtk.Button({ label: _("Add") });
         button_add.set_css_classes(["suggested-action"]);
         button_add.valign = Gtk.Align.CENTER;
-        button_add.connect("clicked", this._overtakeScanRow.bind(this, builder, adwrow));
+        button_add.connect("clicked", this._overtakeScanRow.bind(this, builder, settings, adwrow));
         adwrow.add_suffix(button_add);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnome-shell-extension-messagingmenu",
-  "version": "1.0.0",
+  "version": "51.0.0",
   "description": "A Messaging Menu for the Gnome Shell. All email, chat, and microblogging applications in one place.",
   "main": "messagingmenu@lauinger-clan.de/extension.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add GNOME Shell 51 compatibility, update the release version to `51.0`, and remove GNOME Shell 48 from the supported version list.
- Replace the deprecated panel button event handling with `Clutter.ClickGesture`: left click opens the menu, middle click opens preferences, and right click toggles the menu.
- Preserve an already-detected notification match while checking email sources, preventing later checks from incorrectly clearing the new-message state.
- Make the application chooser resolve cleanly when selecting, cancelling, or closing the dialog, while disconnecting temporary signal handlers.
- Include the indicator wiggle setting when resetting preferences to defaults.

## Review focus

- Verify the indicator's left-, middle-, and right-click behavior on GNOME Shell 51.
- Confirm email/chat notification matches continue to set the indicator state correctly when multiple sources are present.
- Check that the application chooser can be selected, cancelled, and closed repeatedly without stale signal handlers.
- Confirm resetting preferences also restores the indicator wiggle setting.
- Verify the updated `shell-version` and `version-name` values in `metadata.json`.

## Compatibility notes

- GNOME Shell 51 is now supported.
- GNOME Shell 48 is no longer declared as supported; GNOME Shell 49 and 50 remain supported.
