### PR TITLE
Add install-dependencies helper command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,16 @@ APIs over browser or Node patterns.
 - `messagingmenu.sh`: helper for packing, installing, uploading, and updating translations.
 - `.github/workflows/`: CI, release, and stale issue workflows.
 
-## Common Commands
+## Useful Commands
 
+- `./messagingmenu.sh install-dependencies`: install the locked JavaScript dependencies.
 - `npm run lint`: run ESLint across the repository.
 - `./messagingmenu.sh zip`: build `messagingmenu@lauinger-clan.de.shell-extension.zip`.
 - `./messagingmenu.sh install`: build if needed, install, and enable the extension locally.
 - `./messagingmenu.sh translate`: regenerate `po/messagingmenu.pot` and update existing `.po` files.
+
+Run `./messagingmenu.sh install-dependencies` after pulling or rebasing remote
+changes that modify `package-lock.json`, particularly Renovate updates.
 
 There is no useful automated test suite at the moment. `npm test` intentionally
 fails with the default placeholder script. For behavioral changes, use linting

--- a/messagingmenu.sh
+++ b/messagingmenu.sh
@@ -76,6 +76,9 @@ update_version() {
 }
 
 case "${1:-}" in
+  install-dependencies)
+    npm ci
+    ;;
   cleanup)
     if [[ -f "$extensionfile" ]]; then
       rm -- "$extensionfile"
@@ -131,7 +134,7 @@ case "${1:-}" in
     echo "Done."
     ;;
   *)
-    echo "Usage: $0 {zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
+    echo "Usage: $0 {install-dependencies|zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- add an `install-dependencies` command to the repository helper that runs `npm ci` from the repository root
- include the command in the helper usage output
- document running the command after lockfile changes, particularly Renovate updates

## Validation

- helper shell syntax check
- `install-dependencies` command
- `npm run lint`
- helper usage output
- generated artifact scan
